### PR TITLE
Fix for module not installing when zip already present in ProgramData

### DIFF
--- a/lenovo-device-health/Log Analytics/Get-LenovoDeviceStatus.ps1
+++ b/lenovo-device-health/Log Analytics/Get-LenovoDeviceStatus.ps1
@@ -121,6 +121,7 @@ else
         else
         {
             Write-Output "LDMM ZIP file already exists. Skipping download."
+            Expand-Archive -Path (Join-Path -Path $ModuleTemp -ChildPath ldmm_1.0.0.zip) -DestinationPath $ModulePath -Force
         }
 
         # Check if the module was imported successfully


### PR DESCRIPTION
If the zip file is already in the ProgramData folder it does not get properly extracted and installed to the PowerShell modules folder and script always fails.  Fix adds the zip extraction to the else block to ensure it gets installed properly.